### PR TITLE
Define unichr() and unicode in Python 3

### DIFF
--- a/interrogative/src/model.py
+++ b/interrogative/src/model.py
@@ -13,6 +13,11 @@ from interrogative.src.util import to_json
 
 __model = None
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class Interrogative:
     """

--- a/interrogative/src/util.py
+++ b/interrogative/src/util.py
@@ -6,6 +6,11 @@ tools
 """
 import demjson
 
+try:
+    unichr        # Python 2
+except NameError:
+    unichr = chr  # Python 3
+
 
 def to_json(text):
     return demjson.decode(text, encoding='utf-8')


### PR DESCRIPTION
1. __unichr()__ was removed in Python 3 because all __chr__ are Unicode.
2. __unicode__ was removed in Python 3 because all __str__ are Unicode.

[flake8](http://flake8.pycqa.org) testing of https://github.com/lpty/nlp_base on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./interrogative/src/util.py:27:18: F821 undefined name 'unichr'
        b_str += unichr(inside_code)
                 ^
./interrogative/src/util.py:40:18: F821 undefined name 'unichr'
        q_str += unichr(inside_code)
                 ^
./interrogative/src/model.py:85:37: F821 undefined name 'unicode'
        assert isinstance(sentence, unicode), 'Sentence must be unicode.'
                                    ^
3     F821 undefined name 'unicode'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
